### PR TITLE
Don't suggest using -e flag for docker's image arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ How to use
 Simple command line usage:
 
 ```
-docker run -p 11021:21 -it --rm -e FTP_USER=scott -e FTP_PASS=tiger -e mauler/simple-ftp-server
+docker run -p 11021:21 -it --rm -e FTP_USER=scott -e FTP_PASS=tiger mauler/simple-ftp-server
 ```
 
 You can test using:


### PR DESCRIPTION
`-e` flag is not needed and causes an error.

```
docker run --help

Usage:	docker run [OPTIONS] IMAGE [COMMAND] [ARG...]
```